### PR TITLE
Infinite loops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.nyc_output
+dist

--- a/src/css.js
+++ b/src/css.js
@@ -156,8 +156,16 @@ function tokenize(css) {
 			pos = css.length;
 	}
 
-	while (pos < css.length)
+	let prevPos = pos;
+	while (pos < css.length) {
 		next();
+		if (prevPos === pos) {
+			const snippet = css.substring(Math.min(pos - 10), Math.max(pos + 10, css.length - 1))
+			throw new Error(`css tokenizer stopped advancing at pos ${pos} near "${snippet}"`);
+			break;
+		}
+		prevPos = pos;
+	}
 
 //	const fs = require('fs');
 //	fs.writeFileSync(__dirname + '/tokens.json', JSON.stringify(tokens, null, 2), 'utf8');

--- a/src/css.js
+++ b/src/css.js
@@ -162,7 +162,6 @@ function tokenize(css) {
 		if (prevPos === pos) {
 			const snippet = css.substring(Math.min(pos - 10), Math.max(pos + 10, css.length - 1))
 			throw new Error(`css tokenizer stopped advancing at pos ${pos} near "${snippet}"`);
-			break;
 		}
 		prevPos = pos;
 	}

--- a/src/css.js
+++ b/src/css.js
@@ -160,7 +160,7 @@ function tokenize(css) {
 	while (pos < css.length) {
 		next();
 		if (prevPos === pos) {
-			const snippet = css.substring(Math.min(pos - 10), Math.max(pos + 10, css.length - 1))
+			const snippet = css.substring(Math.max(pos - 10, 0), Math.min(pos + 10, css.length - 1))
 			throw new Error(`css tokenizer stopped advancing at pos ${pos} near "${snippet}"`);
 		}
 		prevPos = pos;

--- a/src/dropcss.js
+++ b/src/dropcss.js
@@ -41,14 +41,20 @@ function dropKeyFrames(css, shouldDrop) {
 	// defined
 	let RE = /@(?:-\w+-)?keyframes\s+([\w-]+)\s*\{/gm, m;
 
+	let infiniteLoop = 0
 	while (m = RE.exec(css)) {
 		let ch = takeUntilMatchedClosing(css, RE.lastIndex, '{', '}');
 		defs.push([m.index, m[0].length + ch.length + 1, m[1]]);
+		infiniteLoop++
+		if (infiniteLoop > css.length) {
+			throw new Error('dropKeyFrames looped too much. (loop 1)')
+		}
 	}
 
 	// used
 	let RE2 = /animation(?:-name)?:([^;!}]+)/gm;
 
+	infiniteLoop = 0
 	while (m = RE2.exec(css)) {
 		m[1].trim().split(",").forEach(a => {
 			a = a.trim();
@@ -60,6 +66,10 @@ function dropKeyFrames(css, shouldDrop) {
 
 			used.add(keyFramesName);
 		});
+		infiniteLoop++
+		if (infiniteLoop > css.length) {
+			throw new Error('dropKeyFrames looped too much. (loop 2)')
+		}
 	}
 
 	return removeBackwards(css, defs, used, shouldDrop, '@keyframes ');
@@ -72,14 +82,20 @@ function dropFontFaces(css, shouldDrop) {
 	// defined
 	let RE = /@font-face[\s\S]+?font-family:\s*(['"\w-]+)[^}]+\}/gm, m;
 
+	let infiniteLoop = 0
 	while (m = RE.exec(css)) {
 		let clean = m[1].replace(/['"]/gm, '');
 		defs.push([m.index, m[0].length, clean]);
+		infiniteLoop++
+		if (infiniteLoop > css.length) {
+			throw new Error('dropFontFaces looped too much. (loop 1)')
+		}
 	}
 
 	// used
 	let RE2 = /font-family:([^;!}]+)/gm;
 
+	infiniteLoop = 0
 	while (m = RE2.exec(css)) {
 		let inDef = defs.some(d => m.index > d[0] && m.index < d[0] + d[1]);
 
@@ -87,6 +103,10 @@ function dropFontFaces(css, shouldDrop) {
 			m[1].trim().split(",").forEach(a => {
 				used.add(a.trim().replace(/['"]/gm, ''));
 			});
+		}
+		infiniteLoop++
+		if (infiniteLoop > css.length) {
+			throw new Error('dropFontFaces looped too much. (loop 2)')
 		}
 	}
 

--- a/src/find.js
+++ b/src/find.js
@@ -61,7 +61,7 @@ function matchesNth(pos, val) {
 // maybe look at next non-* selector and check it it has any children/desc?
 function find(m, ctx) {
 	let name, val, mat, par, tidx, res;
-
+	let prevIdx = ctx.idx
 	while (ctx.idx > -1) {
 		switch(m[ctx.idx]) {
 			case '_':
@@ -188,6 +188,10 @@ function find(m, ctx) {
 
 		if (!res)
 			break;
+		if (prevIdx === ctx.idx) {
+			throw new Error(`find stopped advancing at idx ${ctx.idx}`)
+		}
+		prevIdx = ctx.idx
 	}
 
 	return res;

--- a/src/html.js
+++ b/src/html.js
@@ -69,7 +69,6 @@ function tokenize(html) {
 		if (prevPos === pos) {
 			const snippet = html.substring(Math.min(pos - 10), Math.max(pos + 10, html.length - 1))
 			throw new Error(`html tokenizer stopped advancing at pos ${pos} near "${snippet}"`);
-			break;
 		}
 		prevPos = pos;
 	}

--- a/src/html.js
+++ b/src/html.js
@@ -67,7 +67,7 @@ function tokenize(html) {
 	while (pos < html.length) {
 		next();
 		if (prevPos === pos) {
-			const snippet = html.substring(Math.min(pos - 10), Math.max(pos + 10, html.length - 1))
+			const snippet = html.substring(Math.max(pos - 10, 0), Math.min(pos + 10, html.length - 1))
 			throw new Error(`html tokenizer stopped advancing at pos ${pos} near "${snippet}"`);
 		}
 		prevPos = pos;

--- a/src/html.js
+++ b/src/html.js
@@ -63,8 +63,16 @@ function tokenize(html) {
 			syncPos(RE.TEXT);
 	}
 
-	while (pos < html.length)
+	let prevPos = pos;
+	while (pos < html.length) {
 		next();
+		if (prevPos === pos) {
+			const snippet = html.substring(Math.min(pos - 10), Math.max(pos + 10, html.length - 1))
+			throw new Error(`html tokenizer stopped advancing at pos ${pos} near "${snippet}"`);
+			break;
+		}
+		prevPos = pos;
+	}
 
 	syncPos({lastIndex: 0});
 

--- a/src/sel.js
+++ b/src/sel.js
@@ -89,9 +89,14 @@ function parse(sel) {
 
 		return matched;
 	}
-
-	while (idx < sel.length)
+	let prevIdx = idx;
+	while (idx < sel.length) {
 		next();
+		if (prevIdx === idx) {
+			throw new Error(`sel stopped advancing at idx ${idx}`);
+		}
+		prevIdx = idx;
+	}
 
 	return toks;
 }


### PR DESCRIPTION
#19 

Adds some protection so that dropcss will throw instead of looping forever. The underlying issue is a parsing error, but this keeps the fastest unused css removal script from taking literally forever.