### PR TITLE
Evaluation lead: [ContextTesting]

### DIFF
--- a/.alamoderc.json
+++ b/.alamoderc.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "test-build": {
+      "import": {
+        "replacement": {
+          "from": "^((../)+)src/dropcss",
+          "to": "$1"
+        }
+      }
+    }
+  }
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Zoroaster",
+      "program": "${workspaceFolder}/node_modules/.bin/zoroaster",
+      "args": [
+        "test/spec",
+        "test/mask",
+        "-a",
+        "-w",
+        "-t",
+        "9999999"
+      ],
+      "console": "integratedTerminal",
+      "skipFiles": [
+        "<node_internals>/**/*.js"
+      ]
+    },
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "An exceptionally fast, thorough and tiny unused-CSS cleaner",
   "main": "./dist/dropcss.cjs.js",
   "scripts": {
+    "spec": "zoroaster -a test/spec",
+    "mask": "zoroaster -a test/mask",
+    "test-build": "ALAMODE_ENV=test-build zoroaster -a test/mask test/spec",
+    "zoroaster": "zoroaster -a test/mask test/spec",
     "build": "rollup -c",
     "test": "nyc mocha test/src/*.js",
     "coverage": "nyc report --reporter=lcov --reporter=text > ./test/coverage.txt"
@@ -30,6 +34,7 @@
     "rollup": "^1.23.1",
     "rollup-plugin-buble": "^0.19.8",
     "rollup-plugin-cjs-es": "^0.9.0",
-    "rollup-plugin-terser": "^5.1.2"
+    "rollup-plugin-terser": "^5.1.2",
+    "zoroaster": "^4.1.2"
   }
 }

--- a/test/context/index.js
+++ b/test/context/index.js
@@ -1,0 +1,24 @@
+import { readFileSync } from 'fs'
+import vkbeautify from '../bench/lib/vkbeautify'
+import { join } from 'path'
+
+export default class Context {
+  /**
+   * Reads the file from the filesystem
+   * @param {string} path
+   */
+  readFile(path) {
+    return readFileSync(path, 'utf8')
+  }
+  /**
+   * Reads the file from the benchmark dir.
+   * @param {string[]} path
+   */
+  readBench(...path) {
+    const p = join(__dirname, '../bench', ...path)
+    return this.readFile(p)
+  }
+  get vkbeautify() {
+    return vkbeautify
+  }
+}

--- a/test/mask/default.js
+++ b/test/mask/default.js
@@ -1,0 +1,26 @@
+import makeTestSuite from '@zoroaster/mask'
+import dropcss from '../../src/dropcss'
+
+// todo: test [foo="val"], [foo='val'], :not([attr~=value])
+// *-child assertions dont make to test in a unary selector since all root elements will be first/last/only "children"
+const contextFreeUnarySel = makeTestSuite('test/result/0-context-free-unary-sel', {
+  getResults() {
+    let html, css
+    if (!this.preamble) {
+      [html, ...css] = this.input.split('\n')
+      css = css.join('\n')
+    } else {
+      html = this.preamble
+      css = this.input
+    }
+    ;[,html] = /content: '(.+?)'/.exec(html)
+    return dropcss({ html, css })
+  },
+  mapActual({ css }) {
+    return css
+  }
+})
+
+export default {
+  'Context-free, unary selector': contextFreeUnarySel
+}

--- a/test/result/0-context-free-unary-sel/#id.scss
+++ b/test/result/0-context-free-unary-sel/#id.scss
@@ -1,0 +1,27 @@
+html { content: '<div id="a"></div>' }
+
+// should retain present
+#a {a:b;}
+
+/* expected */
+#a{a:b;}
+/**/
+
+// should drop absent
+#b {a:b;}
+
+/* expected */
+/**/
+
+// :not - should retain present
+:not(#b) {a:b;}
+
+/* expected */
+:not(#b){a:b;}
+/**/
+
+// :not - should drop absent
+:not(#a) {a:b;}
+
+/* expected */
+/**/

--- a/test/result/0-context-free-unary-sel/.class.scss
+++ b/test/result/0-context-free-unary-sel/.class.scss
@@ -1,0 +1,27 @@
+html { content: '<div class="a"></div>' }
+
+// should retain present
+.a {a:b;}
+
+/* expected */
+.a{a:b;}
+/**/
+
+// should drop absent
+.b {a:b;}
+
+/* expected */
+/**/
+
+// :not - should retain present
+:not(.b) {a:b;}
+
+/* expected */
+:not(.b){a:b;}
+/**/
+
+// :not - should drop absent
+:not(.a){a:b;}
+
+/* expected */
+/**/

--- a/test/result/0-context-free-unary-sel/<tag>.scss
+++ b/test/result/0-context-free-unary-sel/<tag>.scss
@@ -1,0 +1,27 @@
+html { content: '<div></div>' }
+
+// should retain present
+div {a:b;}
+
+/* expected */
+div{a:b;}
+/**/
+
+// should drop absent
+span {a:b;}
+
+/* expected */
+/**/
+
+// :not - should retain present
+:not(span) {a:b;}
+
+/* expected */
+:not(span){a:b;}
+/**/
+
+// :not - should drop absent
+:not(div) {a:b;}
+
+/* expected */
+/**/

--- a/test/result/0-context-free-unary-sel/<tag⁄>.scss
+++ b/test/result/0-context-free-unary-sel/<tag⁄>.scss
@@ -1,0 +1,27 @@
+html { content: '<div/>' }
+
+// should retain present
+div {a:b;}
+
+/* expected */
+div{a:b;}
+/**/
+
+// should drop absent
+span {a:b;}
+
+/* expected */
+/**/
+
+// :not - should retain present
+:not(span) {a:b;}
+
+/* expected */
+:not(span){a:b;}
+/**/
+
+// :not - should drop absent
+:not(div) {a:b;}
+
+/* expected */
+/**/

--- a/test/result/0-context-free-unary-sel/attr/:not.scss
+++ b/test/result/0-context-free-unary-sel/attr/:not.scss
@@ -1,0 +1,74 @@
+// [attr]: should retain present
+html { content: '<div foo></div>' }
+:not([bar]) {a:b;}
+
+/* expected */
+:not([bar]){a:b;}
+/**/
+
+// [attr]: should drop absent
+html { content: '<div foo></div>' }
+:not([foo]){a:b;}
+
+/* expected */
+/**/
+
+// [attr=value]: should retain present
+html { content: '<div foo="bar"></div>' }
+:not([foo=cow]) {a:b;}
+
+/* expected */
+:not([foo=cow]){a:b;}
+/**/
+
+// [attr=value]: should drop absent
+html { content: '<div foo="bar"></div>' }
+:not([foo=bar]){a:b;}
+
+/* expected */
+/**/
+
+// [attr*=value]: should retain present
+html { content: '<div foo="bar"></div>' }
+:not([foo*=c]) {a:b;}
+
+/* expected */
+:not([foo*=c]){a:b;}
+/**/
+
+// [attr*=value]: should drop absent
+html { content: '<div foo="bar"></div>' }
+:not([foo*=a]){a:b;}
+
+/* expected */
+/**/
+
+// [attr^=value]: should retain present
+html { content: '<div foo="bar"></div>' }
+:not([foo^=c]) {a:b;}
+
+/* expected */
+:not([foo^=c]){a:b;}
+/**/
+
+// [attr^=value]: should drop absent
+html { content: '<div foo="bar"></div>' }
+:not([foo^=b]){a:b;}
+
+/* expected */
+/**/
+
+// [attr$=value]: should retain present
+html { content: '<div foo="bar"></div>' }
+:not([foo$=z]) {a:b;}
+
+/* expected */
+:not([foo$=z]){a:b;}
+/**/
+
+// [attr$=value]: should drop absent
+html { content: '<div foo="bar"></div>' }
+:not([foo$=r]) {a:b;}
+
+/* expected */
+/**/

--- a/test/result/0-context-free-unary-sel/attr/default.scss
+++ b/test/result/0-context-free-unary-sel/attr/default.scss
@@ -1,0 +1,112 @@
+// [attr]: should retain present
+html { content: '<div foo></div>' }
+[foo] {a:b;}
+
+/* expected */
+[foo]{a:b;}
+/**/
+
+// [attr]: should drop absent
+html { content: '<div foo></div>' }
+[bar] {a:b;}
+
+/* expected */
+/**/
+
+// [attr=value]: should retain present
+html { content: '<div foo="bar"></div>' }
+[foo=bar] {a:b;}
+
+/* expected */
+[foo=bar]{a:b;}
+/**/
+
+// [attr=value]: should drop absent
+html { content: '<div foo="bar"></div>' }
+[foo=cow] {a:b;}
+
+/* expected */
+/**/
+
+// [attr*=value]: should retain present
+html { content: '<div foo="bar"></div>' }
+[foo*=a] {a:b;}
+
+/* expected */
+[foo*=a]{a:b;}
+/**/
+
+// [attr*=value]: should drop absent
+html { content: '<div foo="bar"></div>' }
+[foo*=c] {a:b;}
+
+/* expected */
+/**/
+
+// [attr^=value]: should retain present
+html { content: '<div foo="bar"></div>' }
+[foo^=b] {a:b;}
+
+/* expected */
+[foo^=b]{a:b;}
+/**/
+
+// [attr^=value]: should drop absent
+html { content: '<div foo="bar"></div>' }
+[foo*=c] {a:b;}
+
+/* expected */
+/**/
+
+// [attr$=value]: should retain present
+html { content: '<div foo="bar"></div>' }
+[foo$=r] {a:b;}
+
+/* expected */
+[foo$=r]{a:b;}
+/**/
+
+// [attr$=value]: should drop absent
+html { content: '<div foo="bar"></div>' }
+[foo$=z] {a:b;}
+
+/* expected */
+/**/
+
+// [attr~=value]: should retain present
+html { content: '<div foo="bar"></div>' }
+[foo~=bar] {a:b;}
+
+/* expected */
+[foo~=bar]{a:b;}
+/**/
+
+// [attr~=value]: should retain present (multiple first)
+html { content: '<div foo="bar baz"></div>' }
+[foo~=bar] {a:b;}
+
+/* expected */
+[foo~=bar]{a:b;}
+/**/
+
+// [attr~=value]: should retain present (multiple second)
+html { content: '<div foo="baz bar"></div>' }
+[foo~=bar] {a:b;}
+
+/* expected */
+[foo~=bar]{a:b;}
+/**/
+
+// [attr~=value]: should drop absent
+html { content: '<div foo="bar-baz"></div>' }
+[foo~=bar] {a:b;}
+
+/* expected */
+/**/
+
+// [attr~=value]: should drop absent (reverse)
+html { content: '<div foo="baz-bar"></div>' }
+[foo~=bar] {a:b;}
+
+/* expected */
+/**/

--- a/test/result/0-context-free-unary-sel/default.scss
+++ b/test/result/0-context-free-unary-sel/default.scss
@@ -1,0 +1,7 @@
+// *: should retain present
+html { content: '<div></div>' }
+* {a:b;}
+
+/* expected */
+*{a:b;}
+/**/

--- a/test/snapshot/default/Bulma-Bootstrap-Surveillance/stress-test.css
+++ b/test/snapshot/default/Bulma-Bootstrap-Surveillance/stress-test.css
@@ -1,0 +1,349 @@
+*,::after,::before{
+    box-sizing:border-box
+}
+html{
+    font-family:sans-serif;
+    line-height:1.15;
+    -webkit-text-size-adjust:100%;
+    -webkit-tap-highlight-color:transparent
+}
+body{
+    margin:0;
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
+    font-size:1rem;
+    font-weight:400;
+    line-height:1.5;
+    color:#212529;
+    text-align:left;
+    background-color:#fff
+}
+h1,h2,h3,h4{
+    margin-top:0;
+    margin-bottom:.5rem
+}
+p{
+    margin-top:0;
+    margin-bottom:1rem
+}
+abbr[title]{
+    text-decoration:underline;
+    -webkit-text-decoration:underline dotted;
+    text-decoration:underline dotted;
+    cursor:help;
+    border-bottom:0;
+    -webkit-text-decoration-skip-ink:none;
+    text-decoration-skip-ink:none
+}
+dl,ol,ul{
+    margin-top:0;
+    margin-bottom:1rem
+}
+ul ul{
+    margin-bottom:0
+}
+dd{
+    margin-bottom:.5rem;
+    margin-left:0
+}
+blockquote{
+    margin:0 0 1rem
+}
+b{
+    font-weight:bolder
+}
+small{
+    font-size:80%
+}
+sup{
+    position:relative;
+    font-size:75%;
+    line-height:0;
+    vertical-align:baseline
+}
+sup{
+    top:-.5em
+}
+a{
+    color:#007bff;
+    text-decoration:none;
+    background-color:transparent
+}
+a:hover{
+    color:#0056b3;
+    text-decoration:underline
+}
+a:not([href]):not([tabindex]){
+    color:inherit;
+    text-decoration:none
+}
+a:not([href]):not([tabindex]):focus,a:not([href]):not([tabindex]):hover{
+    color:inherit;
+    text-decoration:none
+}
+a:not([href]):not([tabindex]):focus{
+    outline:0
+}
+code{
+    font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+    font-size:1em
+}
+img{
+    vertical-align:middle;
+    border-style:none
+}
+table{
+    border-collapse:collapse
+}
+caption{
+    padding-top:.75rem;
+    padding-bottom:.75rem;
+    color:#6c757d;
+    text-align:left;
+    caption-side:bottom
+}
+th{
+    text-align:inherit
+}
+label{
+    display:inline-block;
+    margin-bottom:.5rem
+}
+input{
+    margin:0;
+    font-family:inherit;
+    font-size:inherit;
+    line-height:inherit
+}
+input{
+    overflow:visible
+}
+[type=submit]{
+    -webkit-appearance:button
+}
+[type=submit]:not(:disabled){
+    cursor:pointer
+}
+[type=submit]::-moz-focus-inner{
+    padding:0;
+    border-style:none
+}
+input[type=checkbox]{
+    box-sizing:border-box;
+    padding:0
+}
+[type=search]{
+    outline-offset:-2px;
+    -webkit-appearance:none
+}
+[type=search]::-webkit-search-decoration{
+    -webkit-appearance:none
+}
+::-webkit-file-upload-button{
+    font:inherit;
+    -webkit-appearance:button
+}
+h1,h2,h3,h4{
+    margin-bottom:.5rem;
+    font-weight:500;
+    line-height:1.2
+}
+h1{
+    font-size:2.5rem
+}
+h2{
+    font-size:2rem
+}
+h3{
+    font-size:1.75rem
+}
+h4{
+    font-size:1.5rem
+}
+small{
+    font-size:80%;
+    font-weight:400
+}
+code{
+    font-size:87.5%;
+    color:#e83e8c;
+    word-break:break-word
+}
+.navbar{
+    position:relative;
+    display:flex;
+    flex-wrap:wrap;
+    align-items:center;
+    justify-content:space-between;
+    padding:.5rem 1rem
+}
+@media print{
+    *,::after,::before{
+        text-shadow:none!important;
+        box-shadow:none!important
+    }
+    a:not(.btn){
+        text-decoration:underline
+    }
+    abbr[title]::after{
+        content:" (" attr(title) ")"
+    }
+    blockquote{
+        border:1px solid #adb5bd;
+        page-break-inside:avoid
+    }
+    img,tr{
+        page-break-inside:avoid
+    }
+    h2,h3,p{
+        orphans:3;
+        widows:3
+    }
+    h2,h3{
+        page-break-after:avoid
+    }
+    @page{
+        size:a3
+    }
+    body{
+        min-width:992px!important
+    }
+    .navbar{
+        display:none
+    }
+}
+blockquote,body,dd,dl,h1,h2,h3,h4,html,li,ol,p,ul{
+    margin:0;
+    padding:0
+}
+h1,h2,h3,h4{
+    font-size:100%;
+    font-weight:400
+}
+ul{
+    list-style:none
+}
+input{
+    margin:0
+}
+html{
+    box-sizing:border-box
+}
+*,::after,::before{
+    box-sizing:inherit
+}
+img{
+    height:auto;
+    max-width:100%
+}
+table{
+    border-collapse:collapse;
+    border-spacing:0
+}
+td,th{
+    padding:0;
+    text-align:left
+}
+html{
+    background-color:#fff;
+    font-size:16px;
+    -moz-osx-font-smoothing:grayscale;
+    -webkit-font-smoothing:antialiased;
+    min-width:300px;
+    overflow-x:hidden;
+    overflow-y:scroll;
+    text-rendering:optimizeLegibility;
+    -webkit-text-size-adjust:100%;
+    -moz-text-size-adjust:100%;
+    -ms-text-size-adjust:100%;
+    text-size-adjust:100%
+}
+body,input{
+    font-family:BlinkMacSystemFont,-apple-system,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif
+}
+code{
+    -moz-osx-font-smoothing:auto;
+    -webkit-font-smoothing:auto;
+    font-family:monospace
+}
+body{
+    color:#4a4a4a;
+    font-size:1rem;
+    font-weight:400;
+    line-height:1.5
+}
+a{
+    color:#3273dc;
+    cursor:pointer;
+    text-decoration:none
+}
+a:hover{
+    color:#363636
+}
+code{
+    background-color:#f5f5f5;
+    color:#ff3860;
+    font-size:.875em;
+    font-weight:400;
+    padding:.25em .5em .25em
+}
+img{
+    height:auto;
+    max-width:100%
+}
+input[type=checkbox]{
+    vertical-align:baseline
+}
+small{
+    font-size:.875em
+}
+span{
+    font-style:inherit;
+    font-weight:inherit
+}
+table td,table th{
+    text-align:left;
+    vertical-align:top
+}
+table th{
+    color:#363636
+}
+.image{
+    display:block;
+    position:relative
+}
+.image img{
+    display:block;
+    height:auto;
+    width:100%
+}
+.menu{
+    font-size:1rem
+}
+.navbar{
+    background-color:#fff;
+    min-height:3.25rem;
+    position:relative;
+    z-index:30
+}
+@media screen and (min-width:1088px){
+    .navbar{
+        align-items:stretch;
+        display:flex
+    }
+    .navbar{
+        min-height:3.25rem
+    }
+}
+.columns{
+    margin-left:-.75rem;
+    margin-right:-.75rem;
+    margin-top:-.75rem
+}
+.columns:not(:last-child){
+    margin-bottom:calc(1.5rem - .75rem)
+}
+@media screen and (min-width:769px),print{
+    .columns:not(.is-desktop){
+        display:flex
+    }
+}

--- a/test/spec/default.js
+++ b/test/spec/default.js
@@ -1,0 +1,34 @@
+import { equal } from '@zoroaster/assert'
+import ServiceContext from 'zoroaster'
+import Context from '../context'
+import dropcss from '../../src/dropcss'
+
+/**
+ * @type {TestSuite1}
+ */
+const T = {
+  context: [Context, ServiceContext],
+  'Bulma-Bootstrap-Surveillance': {
+    'stress test'({ readBench, vkbeautify }, { snapshotExtension }) {
+      snapshotExtension('css')
+      const html = readBench('stress/input', 'surveillance.html')
+      const bootstrap = readBench('stress/input', 'bootstrap.min.css')
+      const bulma = readBench('stress/input', 'bulma.min.css')
+      const css = `${bootstrap}${bulma}`
+      const { css: out } = dropcss({ html, css })
+      const res = vkbeautify(out)
+      try {
+        equal(res, readBench('stress/output', 'dropcss.pretty.css'))
+      } catch (err) {
+        console.warn(err.message)
+      }
+      return res // visual snapshot testing
+    }
+  }
+}
+export default T
+
+
+/** @typedef {Object<string, Test & TestSuite0>} TestSuite1 */
+/** @typedef {Object<string, Test>} TestSuite0 */
+/** @typedef {(c: Context, z: ServiceContext)} Test */


### PR DESCRIPTION
Hi man, I think `dropcss` is an exceptional package. I wanted to showcase you my **context-testing** framework, called Zoroaster. The PR shows how you can benefit from it. It's very small in size and has just 3 transient dependency (no babel no nothing). 

## Masks

The main benefit that is applicable here, is the ability to construct a test mask. A mask is a function that you write once, which will be run against inputs that are extracted from a separate, text file, called mask result. Now you don't need to repeat yourself endlessly, calling the `dropcss` with essentially same params, but different inputs. You can just focus on writing test cases, by providing inputs and expected outputs in a separate file. This saves time and more importantly, allows you to organise tests by files, not by test suites which are functions in mocha. Lots of flexibility. 

Moreover, you get syntax highlighting when your mask results are of the format of the data that you're working with (CSS, the format is `scss` here to allow to write comments which are needed for Zoroaster to split the mask result into test cases):

![Screenshot 2019-10-14 at 02 14 11](https://user-images.githubusercontent.com/21156791/66723949-5a253080-ee28-11e9-9e69-64f27124ac89.png)

You also get to see the visual diff if your mask fails:

![Screenshot 2019-10-14 at 02 15 39](https://user-images.githubusercontent.com/21156791/66723968-8b9dfc00-ee28-11e9-9821-c82451aa0151.png)

And you can jump to the location in the test mask file since its line number is provided. Then you can write _Zoroaster_ in interactive mode (`-i`) to interactively fix the changes in the mask result file:

![Screenshot 2019-10-14 at 02 16 44](https://user-images.githubusercontent.com/21156791/66723976-b0926f00-ee28-11e9-88f9-291bb57ba630.png)

So basically you can add a new test, enter placeholder expected result (e.g., 000), then run in interactive mode to automatically renew the actual output. This is different from snapshot testing, as you don't have to navigate to random snapshots to see what the actual result looks like - much more user-friendly QA in my opinion. 

## Contexts

A context is a piece of testing infrastructure that you keep in a separate file and can reuse across your tests. Now you can put all your testing utils in that context, and access them wherever you need throughout the test suites. Again, this allows to split test cases by files and not test suites, as you just need to import the context in each file, making it reusable. In addition, you will get JSDoc for your methods supported by the context:

![Screenshot 2019-10-14 at 02 21 26](https://user-images.githubusercontent.com/21156791/66724028-5940ce80-ee29-11e9-8f2f-3c5e36747a9e.png)

It's a small example here but you can reuse contexts across packages as well. One of contexts I use a lot is `temp-context` which will create a temp dir and then remove it, so that you can test your packages' writing/reading FS capabilities in literally 2 seconds with full JSDoc support, without copying and pasting beforeEach/afterEach between test suites, which is also not feasible since you can't reuse them across files. The `beforeEach` and `afterEach` are replaced by `async _init()` and `async _destroy()` implemented in a test context. That's why the framework is called _ContextTesting_.

## MISC

- Zoroaster allows to write import/export natively because it's got regex-based transpiler called ÀLaMode. 
- By using a regex in ÀLaMode config, you can run tests against your build, rather than just source files. This will help you to ensure that it's compiled OK. In case of rollup, it's supposed to work OK, but when you have more advanced compilers, like Google Closure, you might run into unexpected bugs if property names got mangled. Running tests against build is a good practice. 
- You can create snapshots by just returning data from a test. It's file extension can also be set for visual inspection of snapshots. 

## Sum up 

In sum, Zoroaster is a new wave framework that is efficient and focuses on productivity and ease of testing. There are 2 types of tests: specs and masks. Both can use contexts. Masks are great when you're testing textual data and comparing outputs to inputs in a standard way. Masks have additional functionality to test forks, which is great when you're writing Node binaries. It has just 3 dependencies (total 3 new dirs in node_modules) and allows to use import syntax without *Babel* with its 6k transient dependencies.

I know you realise that new open source projects take a lot of effort to gain traction, so I just wanted to show you what are the advantages of my product, on your package. If you like it, great, if not then it's OK no strings attached. I just think it's really hard to get people to make a switch when it comes to something so essential as tests, so I took some time to make a PR. 

One disadvantage, right now, is lack of support for test coverage. But I was hoping to incorporate https://www.npmjs.com/package/c8 which uses latest feature of Node to natively generate coverage. 

Finally, Zoroaster context-testing is just a part of my Node.JS/JavaScript stack called NodeTools. It includes other tools for documentation, building and web development. It's main advantage is complete rejection of Babel and really small size for each package, so that you don't have to wait 5 minutes to install dependencies.

So yeah please let me know what you think, and please bear in mind I'm not doing it to indoctrinate you I'm just trying to build relationships as I don't really accept the policy of just trying to advertise on reddit etc to a bunch of random people it's hard to explain it's like I don't want to go out begging people to use my software i'm quite happy with having small number of downloads it's not what I'm after... ok thanks for attention ☺️ 