### PR TITLE
keep alternate

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -2,7 +2,7 @@
 
 const { parseErr } = require('./err');
 
-const COMMENTS = /\s*\/\*[\s\S]*?\*\/\s*/gm;
+const COMMENTS = /\s*\/\*([\s\S]*?)\*\/\s*/gm;
 const COMBINATORS = /\s*[>~+.#]\s*|\[[^\]]+\]|\s+/gm;
 
 const START_AT = 1;
@@ -175,9 +175,12 @@ function tokenize(css) {
 	return tokens;
 }
 
-function parse(css) {
+function parse(css, keepAlternate) {
 	// strip comments (for now)
-	css = css.replace(COMMENTS, '');
+	css = css.replace(COMMENTS, keepAlternate ? (m, comment) => {
+		if (/^\s*@alternate\s*$/.test(comment)) return m
+		return ''
+	}: '');
 	return tokenize(css);
 }
 

--- a/src/dropcss.js
+++ b/src/dropcss.js
@@ -36,7 +36,7 @@ function dropcss(opts) {
 
 	const shouldDrop = opts.shouldDrop || drop;
 
-	let tokens = parseCSS(opts.css);
+	let tokens = parseCSS(opts.css, opts.keepAlternate);
 
 	LOGGING && log.push([+new Date() - START, 'CSS tokenized']);
 


### PR DESCRIPTION
https://github.com/google/closure-stylesheets requires `/* @alternate */` syntax for same-property declarations. I understand that your motivation behind clearing comments is so to avoid matching rules that are actually commented out, but that wouldn't be an issue with `@alternate`. is it OK? Otherwise I can't compile bootstrap with closure after running it with DropCSS. ta 