### PR TITLE
allow amp ⚡

### DIFF
--- a/dist/dropcss.cjs.js
+++ b/dist/dropcss.cjs.js
@@ -23,7 +23,7 @@ var VOIDS = new Set("area base br col command embed hr img input keygen link met
 var NASTIES = /<!doctype[^>]*>|<!--[\s\S]*?-->|<script[^>]*>[\s\S]*?<\/script>|<style[^>]*>[\s\S]*?<\/style>|<link[^>]*>|<meta[^>]*>/gmi;
 var RE = {
 	NAME: /\s*<([\w-]+)\s*/myi,
-	ATTR: /\s*([\w-:]+)(?:="([^"]*)"|='([^']*)'|=([\w-]+))?\s*/myi,
+	ATTR: /\s*([\w-:⚡]+)(?:="([^"]*)"|='([^']*)'|=([\w-]+))?\s*/myi,
 	TAIL: /\s*(\/?>)\s*/myi,
 	TEXT: /\s*[^<]*/my,
 	CLOSE: /\s*<\/[\w-]+>\s*/myi,

--- a/src/html.js
+++ b/src/html.js
@@ -12,7 +12,7 @@ const VOIDS = new Set("area base br col command embed hr img input keygen link m
 const NASTIES = /<!doctype[^>]*>|<!--[\s\S]*?-->|<script[^>]*>[\s\S]*?<\/script>|<style[^>]*>[\s\S]*?<\/style>|<link[^>]*>|<meta[^>]*>/gmi;
 const RE = {
 	NAME: /\s*<([\w-]+)\s*/myi,
-	ATTR: /\s*([\w-:]+)(?:="([^"]*)"|='([^']*)'|=([\w-]+))?\s*/myi,
+	ATTR: /\s*([\w-:⚡]+)(?:="([^"]*)"|='([^']*)'|=([\w-]+))?\s*/myi,
 	TAIL: /\s*(\/?>)\s*/myi,
 	TEXT: /\s*[^<]*/my,
 	CLOSE: /\s*<\/[\w-]+>\s*/myi,


### PR DESCRIPTION
Currently dropcss fails on amp html documents because of the "⚡" attribute in the html element.
This pull requests adds "⚡" as an attribute